### PR TITLE
Fix _indexNumbers leak in FICImageTable

### DIFF
--- a/FastImageCache/FastImageCache/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageTable.m
@@ -234,6 +234,9 @@ static NSString *const FICImageTableFormatKey = @"format";
 }
 
 - (void)dealloc {
+    if (_indexNumbers != NULL) {
+        CFRelease(_indexNumbers);
+    }
     if (_fileDescriptor >= 0) {
         close(_fileDescriptor);
     }


### PR DESCRIPTION
`_indexNumbers` was allocated in `-init` via `CFDictionaryCreateMutable()`, but not released in `-dealloc`. This fixes it.